### PR TITLE
Handle duplicates and substrings

### DIFF
--- a/completer.go
+++ b/completer.go
@@ -1,23 +1,38 @@
 package completer
 
-type Completer map[string]string
+import "fmt"
 
-func NewCompleter() Completer {
-	return Completer(make(map[string]string))
+type Completer struct {
+	aliases   map[string]string
+	originals map[string]struct{}
 }
 
-func (c Completer) Add(s string) {
-	for i := 0; i < len(s); i++ {
-		prefix := s[:i+1]
-		if _, ok := c[prefix]; ok {
-			delete(c, prefix)
-		} else {
-			c[prefix] = s
+func NewCompleter() Completer {
+	return Completer{aliases: make(map[string]string), originals: make(map[string]struct{})}
+}
+
+func (c Completer) Add(s string) error {
+	if _, ok := c.aliases[s]; ok {
+		if _, ok := c.originals[s]; ok {
+			return fmt.Errorf("unable to add duplicate key %q", s)
 		}
 	}
+	for i := 0; i < len(s); i++ {
+		prefix := s[:i+1]
+		if _, ok := c.originals[prefix]; ok {
+			continue
+		}
+		if _, ok := c.aliases[prefix]; ok {
+			delete(c.aliases, prefix)
+		} else {
+			c.aliases[prefix] = s
+		}
+	}
+	c.originals[s] = struct{}{}
+	return nil
 }
 
 func (c Completer) Lookup(s string) (string, bool) {
-	got, ok := c[s]
+	got, ok := c.aliases[s]
 	return got, ok
 }

--- a/completer_test.go
+++ b/completer_test.go
@@ -66,3 +66,63 @@ func TestCompleter(t *testing.T) {
 		}
 	}
 }
+
+func TestSubstrings(t *testing.T) {
+	c := NewCompleter()
+	for _, tc := range []struct {
+		add  string
+		want map[string]string
+	}{
+		{
+			add: "foo",
+			want: map[string]string{
+				"":    "",
+				"f":   "foo",
+				"fo":  "foo",
+				"foo": "foo",
+			},
+		},
+		{
+			add: "foobar",
+			want: map[string]string{
+				"":       "",
+				"f":      "",
+				"fo":     "",
+				"foo":    "foo",
+				"foob":   "foobar",
+				"fooba":  "foobar",
+				"foobar": "foobar",
+			},
+		},
+	} {
+		c.Add(tc.add)
+		for prefix, want := range tc.want {
+			if got, ok := c.Lookup(prefix); got != want || (got == "" && ok) {
+				t.Errorf("%+v.Lookup(%q) == %q, %t, want %q", c, prefix, got, ok, want)
+			}
+		}
+	}
+}
+
+func TestSubstringLookup(t *testing.T) {
+	c := NewCompleter()
+	c.Add("foor")
+	err := c.Add("fo")
+	if err != nil {
+		t.Errorf("%+v.Add(\"fo\") == %v, want 'nil'", c, err)
+	}
+
+	prefix := "f"
+	if got, ok := c.Lookup(prefix); ok {
+		t.Errorf("%+v.Lookup(%q) == %q, %t, want \"\", false", c, prefix, got, ok)
+	}
+}
+
+func TestDuplicateKey(t *testing.T) {
+	c := NewCompleter()
+	c.Add("foo")
+	err := c.Add("foo")
+	if err == nil {
+		t.Errorf("%+v.Add(\"foo\") == nil, want error", c)
+	}
+}


### PR DESCRIPTION
The current code doesn't handle duplicates nor substrings, i.e. this code: https://play.golang.org/p/Wt_BwooZDM will fail

I suggest to modify the structure of `Completer` to keep track of the original items inserted, so that we can check:
* if an item was already added
* if the item just added is a substring of an item already present, or some item already added is a substring of the one added.

I also update the `Add()` method to raise an error in the latter case. Duplicates are thus silently ignored.