### PR TITLE
Add 'Complete()' method to return a list of all matching strings

### DIFF
--- a/completer.go
+++ b/completer.go
@@ -1,6 +1,9 @@
 package completer
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Completer struct {
 	aliases   map[string]string
@@ -35,4 +38,14 @@ func (c Completer) Add(s string) error {
 func (c Completer) Lookup(s string) (string, bool) {
 	got, ok := c.aliases[s]
 	return got, ok
+}
+
+func (c Completer) Complete(s string) []string {
+	out := []string{}
+	for v := range c.originals {
+		if strings.HasPrefix(v, s) {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/completer_test.go
+++ b/completer_test.go
@@ -1,6 +1,10 @@
 package completer
 
-import "testing"
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
 
 func TestCompleter(t *testing.T) {
 	c := NewCompleter()
@@ -124,5 +128,29 @@ func TestDuplicateKey(t *testing.T) {
 	err := c.Add("foo")
 	if err == nil {
 		t.Errorf("%+v.Add(\"foo\") == nil, want error", c)
+	}
+}
+
+func TestCompleteFunction(t *testing.T) {
+	c := NewCompleter()
+	words := []string{"foobar", "foobaz"}
+	wantWords := map[string][]string{
+		"f":      []string{"foobar", "foobaz"},
+		"fo":     []string{"foobar", "foobaz"},
+		"foo":    []string{"foobar", "foobaz"},
+		"foob":   []string{"foobar", "foobaz"},
+		"fooba":  []string{"foobar", "foobaz"},
+		"foobar": []string{"foobar"},
+	}
+	for _, w := range words {
+		c.Add(w)
+	}
+	for prefix, want := range wantWords {
+		got := c.Complete(prefix)
+		sort.Strings(got)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf(".Complete(%q) == %q, want %q", prefix, got, want)
+		}
 	}
 }


### PR DESCRIPTION
This might be useful in cases where we want to give a feedback of all
possible keys that match the supplied key, for example in a command line
interpreter.